### PR TITLE
Feat/#12 HomeView API  데이터 연동 및 필터링, 기능 구현

### DIFF
--- a/src/components/Home/Content/AngelTicket.jsx
+++ b/src/components/Home/Content/AngelTicket.jsx
@@ -15,8 +15,8 @@ function AngelTicket({ angelData }) {
       </Styled.AngelInfoText>
 
       <Styled.AngelTicketList>
-        {angelData.map((v) => (
-          <Styled.AngelTicketBox key={v}>
+        {angelData.map((v, index) => (
+          <Styled.AngelTicketBox key={v.title}>
             <Styled.AngelTicketImg src={v.imageURL} />
             <Styled.AngelTicektSub>{v.title}</Styled.AngelTicektSub>
             <Styled.AngelTicketSale>{v.discountRate}%</Styled.AngelTicketSale>

--- a/src/components/Home/Content/RealtimeRank.jsx
+++ b/src/components/Home/Content/RealtimeRank.jsx
@@ -1,11 +1,16 @@
 import linkButton from 'assets/Icons/icn_foward_m.svg';
+import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 function RealtimeRank({ ticketData }) {
+  const navigate = useNavigate();
+  const viewRanking = () => {
+    navigate('/ranking');
+  };
   return (
     <Styled.RealtimeRank>
       <Styled.RealtimeInfo>
         <Styled.RealtimeText>실시간 티켓 랭킹</Styled.RealtimeText>
-        <Styled.RealtimeLink src={linkButton} />
+        <Styled.RealtimeLink src={linkButton} onClick={() => viewRanking()} />
       </Styled.RealtimeInfo>
       <Styled.RealtimeRankList>
         <Styled.RankDiv>
@@ -50,7 +55,9 @@ const Styled = {
     display: flex;
     max-height: 14.2rem;
   `,
-  RealtimeLink: styled.img``,
+  RealtimeLink: styled.img`
+    cursor: pointer;
+  `,
   RankDiv: styled.div`
     max-height: 14.2rem;
   `,

--- a/src/components/Home/Content/RecommendTicket.jsx
+++ b/src/components/Home/Content/RecommendTicket.jsx
@@ -16,6 +16,22 @@ function RecommendTicket() {
     getShowData();
   }, [currentGenre]);
 
+  const filterGenre = (showType) => {
+    switch (showType) {
+      case 1:
+        return '콘서트';
+      case 2:
+        return '뮤지컬';
+      case 3:
+        return '연극';
+      case 4:
+        return '클래식';
+      case 5:
+        return '전시회';
+      case 6:
+        return '어린이';
+    }
+  };
   return (
     <Styled.Recommend>
       <Styled.RecommendInfo>
@@ -65,7 +81,7 @@ function RecommendTicket() {
           <Styled.RecommendImg key={ticket.imageURL} src={ticket.imageURL} />
           <Styled.RecoommedDate key={ticket.reservationStartAt}>예매 시간 2022.10.31~2022.11.06</Styled.RecoommedDate>
           <Styled.TicektInfo>
-            <Styled.RecommendGenre key={ticket.showType}>{ticket.showType}</Styled.RecommendGenre>
+            <Styled.RecommendGenre key={ticket.showType}>{filterGenre(ticket.showType)}</Styled.RecommendGenre>
             <Styled.RecommendTitle key={ticket.title}>{ticket.title}</Styled.RecommendTitle>
           </Styled.TicektInfo>
         </Styled.RecommendTicekt>

--- a/src/components/Home/Content/RecommendTicket.jsx
+++ b/src/components/Home/Content/RecommendTicket.jsx
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { client } from 'cores/api';
 import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
@@ -9,7 +10,7 @@ function RecommendTicket() {
     setcurrentGenre(e.target.id);
   };
   const getShowData = async () => {
-    const data = await axios.get(`http://52.3.174.121:3000/show/genre?genreId=${currentGenre}`);
+    const data = await client.get(`/show/genre?genreId=${currentGenre}`);
     setshowData(data.data.data.showList);
   };
   useEffect(() => {

--- a/src/components/Home/Content/RecommendTicket.jsx
+++ b/src/components/Home/Content/RecommendTicket.jsx
@@ -1,11 +1,21 @@
-import { useState } from 'react';
+import axios from 'axios';
+import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 function RecommendTicket() {
   const [currentGenre, setcurrentGenre] = useState(1);
+  const [showData, setshowData] = useState([]);
   const changeGenre = (e) => {
     setcurrentGenre(e.target.id);
   };
+  const getShowData = async () => {
+    const data = await axios.get(`http://52.3.174.121:3000/show/genre?genreId=${currentGenre}`);
+    setshowData(data.data.data.showList);
+  };
+  useEffect(() => {
+    getShowData();
+  }, [currentGenre]);
+
   return (
     <Styled.Recommend>
       <Styled.RecommendInfo>
@@ -49,22 +59,17 @@ function RecommendTicket() {
           </Styled.UnchoicedGenreBox>
         )}
       </Styled.GenreLists>
-      <Styled.RecommendTicekt>
-        <Styled.RecommendImg src="ss" />
-        <Styled.RecoommedDate>예매 시간 2022.10.31~2022.11.06</Styled.RecoommedDate>
-        <Styled.TicektInfo>
-          <Styled.RecommendGenre>뮤지컬</Styled.RecommendGenre>
-          <Styled.RecommendTitle>우리가 사랑했던 그날</Styled.RecommendTitle>
-        </Styled.TicektInfo>
-      </Styled.RecommendTicekt>
-      <Styled.RecommendTicekt>
-        <Styled.RecommendImg src="ss" />
-        <Styled.RecoommedDate>예매 시간 2022.10.31~2022.11.06</Styled.RecoommedDate>
-        <Styled.TicektInfo>
-          <Styled.RecommendGenre>뮤지컬</Styled.RecommendGenre>
-          <Styled.RecommendTitle>우리가 사랑했던 그날</Styled.RecommendTitle>
-        </Styled.TicektInfo>
-      </Styled.RecommendTicekt>
+
+      {showData.map((ticket, index) => (
+        <Styled.RecommendTicekt key={ticket.title}>
+          <Styled.RecommendImg key={ticket.imageURL} src={ticket.imageURL} />
+          <Styled.RecoommedDate key={ticket.reservationStartAt}>예매 시간 2022.10.31~2022.11.06</Styled.RecoommedDate>
+          <Styled.TicektInfo>
+            <Styled.RecommendGenre key={ticket.showType}>{ticket.showType}</Styled.RecommendGenre>
+            <Styled.RecommendTitle key={ticket.title}>{ticket.title}</Styled.RecommendTitle>
+          </Styled.TicektInfo>
+        </Styled.RecommendTicekt>
+      ))}
     </Styled.Recommend>
   );
 }
@@ -103,6 +108,7 @@ const Styled = {
     align-items: center;
     text-align: center;
     border-bottom: 0.2rem solid #333333;
+    cursor: pointer;
   `,
   UnchoicedGenreBox: styled.div`
     width: 20%;
@@ -114,7 +120,7 @@ const Styled = {
     font-size: 12px;
     line-height: 15px;
     color: rgba(51, 51, 51, 0.4);
-
+    cursor: pointer;
     display: flex;
     align-items: center;
     text-align: center;

--- a/src/components/Home/Content/RecommendTicket.jsx
+++ b/src/components/Home/Content/RecommendTicket.jsx
@@ -1,6 +1,11 @@
+import { useState } from 'react';
 import styled from 'styled-components';
 
 function RecommendTicket() {
+  const [currentGenre, setcurrentGenre] = useState(1);
+  const changeGenre = (e) => {
+    setcurrentGenre(e.target.id);
+  };
   return (
     <Styled.Recommend>
       <Styled.RecommendInfo>
@@ -8,11 +13,41 @@ function RecommendTicket() {
         이런 공연은 어떠세요?
       </Styled.RecommendInfo>
       <Styled.GenreLists>
-        <Styled.GenreBox>로맨스</Styled.GenreBox>
-        <Styled.UnchoicedGenreBox>공포</Styled.UnchoicedGenreBox>
-        <Styled.UnchoicedGenreBox>코믹</Styled.UnchoicedGenreBox>
-        <Styled.UnchoicedGenreBox>미스터리</Styled.UnchoicedGenreBox>
-        <Styled.UnchoicedGenreBox>퍼포먼스</Styled.UnchoicedGenreBox>
+        {currentGenre == 1 ? (
+          <Styled.GenreBox>로맨스</Styled.GenreBox>
+        ) : (
+          <Styled.UnchoicedGenreBox id={1} onClick={(e) => changeGenre(e)}>
+            로맨스
+          </Styled.UnchoicedGenreBox>
+        )}
+        {currentGenre == 2 ? (
+          <Styled.GenreBox>공포</Styled.GenreBox>
+        ) : (
+          <Styled.UnchoicedGenreBox id={2} onClick={(e) => changeGenre(e)}>
+            공포
+          </Styled.UnchoicedGenreBox>
+        )}
+        {currentGenre == 3 ? (
+          <Styled.GenreBox>코믹</Styled.GenreBox>
+        ) : (
+          <Styled.UnchoicedGenreBox id={3} onClick={(e) => changeGenre(e)}>
+            코믹
+          </Styled.UnchoicedGenreBox>
+        )}
+        {currentGenre == 4 ? (
+          <Styled.GenreBox>미스터리</Styled.GenreBox>
+        ) : (
+          <Styled.UnchoicedGenreBox id={4} onClick={(e) => changeGenre(e)}>
+            미스터리
+          </Styled.UnchoicedGenreBox>
+        )}
+        {currentGenre == 5 ? (
+          <Styled.GenreBox>퍼포먼스</Styled.GenreBox>
+        ) : (
+          <Styled.UnchoicedGenreBox id={5} onClick={(e) => changeGenre(e)}>
+            퍼포먼스
+          </Styled.UnchoicedGenreBox>
+        )}
       </Styled.GenreLists>
       <Styled.RecommendTicekt>
         <Styled.RecommendImg src="ss" />

--- a/src/components/Home/Content/RecommendTicket.jsx
+++ b/src/components/Home/Content/RecommendTicket.jsx
@@ -32,6 +32,15 @@ function RecommendTicket() {
         return '어린이';
     }
   };
+  const filterDate = (reservation) => {
+    const date = new Date(reservation);
+    const year = date.getFullYear();
+    const month = ('0' + (date.getMonth() + 1)).slice(-2);
+    const day = ('0' + date.getDate()).slice(-2);
+
+    const dateString = year + '.' + month + '.' + day;
+    return dateString;
+  };
   return (
     <Styled.Recommend>
       <Styled.RecommendInfo>
@@ -79,7 +88,9 @@ function RecommendTicket() {
       {showData.map((ticket, index) => (
         <Styled.RecommendTicekt key={ticket.title}>
           <Styled.RecommendImg key={ticket.imageURL} src={ticket.imageURL} />
-          <Styled.RecoommedDate key={ticket.reservationStartAt}>예매 시간 2022.10.31~2022.11.06</Styled.RecoommedDate>
+          <Styled.RecoommedDate key={ticket.reservationStartAt}>
+            예매 시간 {filterDate(ticket.reservationStartAt)}~ {filterDate(ticket.reservationEndAt)}
+          </Styled.RecoommedDate>
           <Styled.TicektInfo>
             <Styled.RecommendGenre key={ticket.showType}>{filterGenre(ticket.showType)}</Styled.RecommendGenre>
             <Styled.RecommendTitle key={ticket.title}>{ticket.title}</Styled.RecommendTitle>

--- a/src/components/Home/Content/TicketSlider.jsx
+++ b/src/components/Home/Content/TicketSlider.jsx
@@ -47,7 +47,7 @@ function TicketSlider({ bannerData }) {
           className="mySwiper">
           {bannerData.map((v) => (
             <Styled.Swiper key={v.id}>
-              <Styled.SwieperImg key={v.url} src="https://swiperjs.com/demos/images/nature-2.jpg" />
+              <Styled.SwieperImg key={v.url} src={v.imageURL} />
             </Styled.Swiper>
           ))}
         </Swiper>

--- a/src/components/Home/Content/TicketSlider.jsx
+++ b/src/components/Home/Content/TicketSlider.jsx
@@ -7,8 +7,6 @@ import 'swiper/css';
 import 'swiper/css/effect-coverflow';
 import 'swiper/css/pagination';
 function TicketSlider({ bannerData }) {
-  // console.log(bannerData);
-
   const SwiperStyle = createGlobalStyle`
     .swiper-pagination-clickable{
     top:1.4rem;

--- a/src/cores/api.js
+++ b/src/cores/api.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
 export const client = axios.create({
-  baseURL: '/api',
+  baseURL: 'http://52.3.174.121:3000',
   header: {
     'Content-Type': 'application/json',
   },

--- a/src/pages/Homeview.jsx
+++ b/src/pages/Homeview.jsx
@@ -7,19 +7,19 @@ import HomeviewHeader from 'components/Home/Header/HomeviewHeader';
 import useAPI from 'cores/hooks/useAPI';
 
 function Home() {
-  const homeData = useAPI('/show/home').data;
+  const homeData = useAPI('http://52.3.174.121:3000/show/home').data;
 
   return (
     <>
-      {homeData === null ? (
+      {homeData === undefined || homeData === null ? (
         <div>로딩중</div>
       ) : (
         <>
           <HomeviewHeader />
-          <TicketSlider bannerData={homeData.bannerList} />
+          <TicketSlider bannerData={homeData.data.bannerList} />
           <GenreChoice />
-          <RealtimeRank ticketData={homeData.rankList} />
-          <AngelTicket angelData={homeData.angelTicketList} />
+          <RealtimeRank ticketData={homeData.data.rankList} />
+          <AngelTicket angelData={homeData.data.angelTicketList} />
           <RecommendTicket />
         </>
       )}


### PR DESCRIPTION
---
Feat/#12 HomeView API  데이터 연동 및 필터링, 기능 구현

---

## ✅ PR check list

- [x] PR 제목: "[#이슈번호] 작업 내용" 
- [x] commit message가 적절한지 확인해주세요.
- [x] 적절한 branch로 요청했는지 확인해주세요.
- [x] Assignees, Label을 붙여주세요.
- [x] 주의 사항과 관련해 꼭 확인해야 할 사람이 있다면 Reviewer로 등록해주세요.

## 📝 PR 요약

https://user-images.githubusercontent.com/39684920/203588992-cd57805e-1f01-4d76-bfe3-ea09f3c0822d.mov



- HomeView 추천 공연 장르 선택 기능
- HomeView API 데이터 연동 및 필터링
- 장르가 API에서 int 형으로 넘어오는 데이터 필터링
- 선택한 장르에 따라 다른 주소에서의 API GET 구현
- 예매기간 DateTime 필터링

## 📌 변경 사항 및 주의 사항

일단, 먼저 API 명세서를 보면서, 데이터를 가공하는 과정이 기존과는 조금 다른 유형이였기에 고민하는 시간이 필요했습니다! 특히, /show/home?genreID=1 이런식의 API 구조였는데, 이렇게 되면 선택한 장르에 따라 API 를 다른 주소에서 호출해야했기에 이 부분에서 코드가 다소 복잡해진 부분이 있는 것 같습니다.

이외에는, 현재 데이터 연결을 모두 완료하였고, 아직 서버측에서 더미데이터 세팅이 완료되지 않은 상태이기에 모든 이미지가 같은 이미지로 출력됩니다! 이는 수정되면 시현영상을 다시 올리도록 하겠습니다

이외에, 조금 지저분하거나 리뷰가 있었으면 하는 코드들에 Comment를 남겨두겠습니다!
<br/>
